### PR TITLE
Preemptive removal of '@line_items ||=' from lib/taxjar/orders.rb and lib/taxjar/refund.rb.  Added specs for both changes.

### DIFF
--- a/lib/taxjar/order.rb
+++ b/lib/taxjar/order.rb
@@ -6,7 +6,7 @@ module Taxjar
       :to_state, :to_city, :to_street, :amount, :shipping, :sales_tax
 
     def line_items
-      @line_items ||= map_collection(Taxjar::LineItem, :line_items)
+      map_collection(Taxjar::LineItem, :line_items)
     end
 
   end

--- a/lib/taxjar/refund.rb
+++ b/lib/taxjar/refund.rb
@@ -7,7 +7,7 @@ module Taxjar
       :to_state, :to_city, :to_street, :amount, :shipping, :sales_tax
 
     def line_items
-      @line_items ||= map_collection(Taxjar::LineItem, :line_items)
+      map_collection(Taxjar::LineItem, :line_items)
     end
   end
 end

--- a/spec/taxjar/api/order_spec.rb
+++ b/spec/taxjar/api/order_spec.rb
@@ -68,6 +68,11 @@ describe Taxjar::API::Order do
       expect(order).to be_an Taxjar::Order
       expect(order.transaction_id).to eq(123)
     end
+
+    it 'allows access to line_items' do
+      order = @client.show_order('123')
+      expect(order.line_items[0].quantity).to eq(1)
+    end
   end
 
   describe "#create_order" do

--- a/spec/taxjar/api/refund_spec.rb
+++ b/spec/taxjar/api/refund_spec.rb
@@ -68,6 +68,11 @@ describe Taxjar::API::Refund do
       expect(refund).to be_an Taxjar::Refund
       expect(refund.transaction_id).to eq(321)
     end
+    
+    it 'allows access to line_items' do
+      refund = @client.show_refund('321')
+      expect(refund.line_items[0].quantity).to eq(1)
+    end
   end
 
   describe "#create_refund" do


### PR DESCRIPTION
Optional fix - previous implementation was not causing any issues but may have in the future.