### PR TITLE
Update breakdown_line_item.rb

### DIFF
--- a/lib/taxjar/breakdown_line_item.rb
+++ b/lib/taxjar/breakdown_line_item.rb
@@ -2,9 +2,9 @@ require 'taxjar/base'
 
 module Taxjar
   class BreakdownLineItem < Taxjar::Base
-    attr_reader :id, :state_taxable_amount, :state_sales_tax_rate, :county_taxable_amount,
-    :county_tax_rate, :city_taxable_amount, :city_tax_rate, :special_district_taxable_amount
-    :special_tax_rate
+    attr_reader :id, :tax_collectable, :state_taxable_amount, :state_sales_tax_rate, :state_amount, 
+    :county_taxable_amount, :county_tax_rate, :county_amount, :city_taxable_amount, :city_tax_rate, :city_amount, 
+    :special_district_taxable_amount, :special_tax_rate, :special_district_amount
 
   end
 end


### PR DESCRIPTION
Updated to match the available attributes... unless there is some reason you are intentionally not providing access to these fields. The amounts in particular are important as if we use the taxable_amount and the rate to calculate the amount we may end up with a different result depending on the data type and rounding rules.
```
2.2.2 :015 > ap x.breakdown.line_items.first.as_json
{
                                 "id" => 100,
                    "tax_collectable" => 4.54,
               "state_taxable_amount" => 51.12,
               "state_sales_tax_rate" => 0.04,
                       "state_amount" => 2.04,
              "county_taxable_amount" => 0,
                    "county_tax_rate" => 0,
                      "county_amount" => 0,
                "city_taxable_amount" => 51.12,
                      "city_tax_rate" => 0.045,
                        "city_amount" => 2.3,
    "special_district_taxable_amount" => 51.12,
                   "special_tax_rate" => 0.00375,
            "special_district_amount" => 0.19
}
```