### PR TITLE
Add timeout options to HTTP requests if set in options

### DIFF
--- a/lib/taxjar/api/request.rb
+++ b/lib/taxjar/api/request.rb
@@ -20,11 +20,12 @@ module Taxjar
         set_request_headers
         @object_key = object_key
         @options = options
+        set_http_timeout
       end
 
       def perform
         options_key = @request_method == :get ? :params : :json
-        response = HTTP.with(headers).public_send(request_method, uri.to_s, options_key =>  @options)
+        response = HTTP.timeout(@http_timeout).with(headers).public_send(request_method, uri.to_s, options_key =>  @options)
         response_body = symbolize_keys!(response.parse)
         fail_or_return_response_body(response.code, response_body)
       end
@@ -35,6 +36,13 @@ module Taxjar
           @headers = {}
           @headers[:user_agent] = client.user_agent
           @headers[:authorization] = "Bearer #{client.api_key}"
+        end
+
+        def set_http_timeout
+          @http_timeout = {}
+          @http_timeout[:write] = @options[:timeout]
+          @http_timeout[:connect] = @options[:timeout]
+          @http_timeout[:read] = @options[:timeout]
         end
 
         def symbolize_keys!(object)


### PR DESCRIPTION
Attempt to set timeout options.

any request can pass an options[:timeout] to set a timeout length (no setting leaves them as nil which defaults to no timeout which is the HTTP gem default).