### PR TITLE
Fix for #22: Wrong type for `:id` in `BreakdownLineItem`

### DIFF
--- a/lib/taxjar/breakdown_line_item.rb
+++ b/lib/taxjar/breakdown_line_item.rb
@@ -3,8 +3,8 @@ require 'taxjar/base'
 module Taxjar
   class BreakdownLineItem < Taxjar::Base
     extend ModelAttribute
-      
-    attribute :id,                              :integer
+
+    attribute :id,                              :string
     attribute :taxable_amount,                  :float
     attribute :tax_collectable,                 :float
     attribute :combined_tax_rate,               :float


### PR DESCRIPTION
Changes the type of `:id` in `BreakdownLineItem` to `:string`, per the TaxJar API reference. Fixes #22.