### PR TITLE
Update Gems to latest versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'yard'
 
 group :test do
   gem 'rspec', '~>3'
-  gem 'webmock', '~>1'
+  gem 'webmock', '~>3.0.1'
 end
 
 # Specify your gem's dependencies in taxjar-ruby.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'yard'
 
 group :test do
   gem 'rspec', '~>3'
-  gem 'webmock', '~>3.0.1'
+  gem 'webmock', '~>2.3.2'
 end
 
 # Specify your gem's dependencies in taxjar-ruby.gemspec

--- a/lib/taxjar/api/request.rb
+++ b/lib/taxjar/api/request.rb
@@ -25,7 +25,8 @@ module Taxjar
 
       def perform
         options_key = @request_method == :get ? :params : :json
-        response = HTTP.timeout(@http_timeout).with(headers).public_send(request_method, uri.to_s, options_key =>  @options)
+        response = HTTP.timeout(@http_timeout).headers(headers)
+          .request(request_method, uri.to_s, options_key =>  @options)
         response_body = symbolize_keys!(response.parse)
         fail_or_return_response_body(response.code, response_body)
       end

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -118,12 +118,11 @@ describe Taxjar::API::Request do
          stub_request(:post, "https://api.taxjar.com/api_path").
                     with(:body => "{\"city\":\"New York\"}",
                          :headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
-                                      'Content-Type'=>'application/json',
+                                      'Content-Type'=>'application/json; charset=UTF-8',
                                       'Host'=>'api.taxjar.com',
                                       'User-Agent'=>"TaxjarRubyGem/#{Taxjar::Version.to_s}"}).
           to_return(:status => 200, :body => '{"object": {"id": "3"}}',
                     :headers => {content_type: 'application/json; charset utf-8'})
-
 
         expect(subject.perform).to eq({id: '3'})
       end

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -118,7 +118,7 @@ describe Taxjar::API::Request do
          stub_request(:post, "https://api.taxjar.com/api_path").
                     with(:body => "{\"city\":\"New York\"}",
                          :headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
-                                      'Content-Type'=>'application/json; charset=UTF-8',
+                                      'Content-Type'=>'application/json',
                                       'Host'=>'api.taxjar.com',
                                       'User-Agent'=>"TaxjarRubyGem/#{Taxjar::Version.to_s}"}).
           to_return(:status => 200, :body => '{"object": {"id": "3"}}',

--- a/taxjar-ruby.gemspec
+++ b/taxjar-ruby.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency 'http', '~> 0.9.4'
+  spec.add_dependency 'http', '~> 2.2.2'
   spec.add_dependency 'memoizable', '~> 0.4.0'
   spec.add_dependency 'taxjar-model_attribute', '~> 3.1'
   spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.0"
 end

--- a/taxjar-ruby.gemspec
+++ b/taxjar-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency 'http', '~> 2.2.2'
+  spec.add_dependency 'http', '~> 1.0.4'
   spec.add_dependency 'memoizable', '~> 0.4.0'
   spec.add_dependency 'taxjar-model_attribute', '~> 3.1'
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
HTTP Gem was using a very outdated version.

I was able to migrate it, along with Webmock and Rake, to the most recent versions with only
minimal changes, and get the test suite passing once again.

Edit: Learned from Travis CI exactly _why_ the gems were outdated. Reverted them to the most recent stable version that works for all the needed ruby versions. In practical terms, this means we have HTTP v1.0.4, which at least gets us into full release territory. :)