### PR TITLE
HTTP Gem Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
 
 rvm:
- - "1.9.3"
  - "2.0"
  - "2.1"
  - "2.2"
+ - "2.3"
+ - "2.4"
 
 script: bundle exec rspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source 'https://rubygems.org'
 gem 'yard'
 
 group :test do
-  gem 'rspec', '~>3'
-  gem 'webmock', '~>2.3.2'
+  gem 'rspec', '~> 3'
+  gem 'webmock', '~> 3.0.1'
 end
 
 # Specify your gem's dependencies in taxjar-ruby.gemspec

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See local jurisdictional tax reports, get payment reminders, and more. You can u
 
 ## Supported Ruby Versions
 
-Ruby 1.9.3 or greater
+Ruby 2.0 or greater
 
 ## Gem Dependencies
 

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -100,7 +100,7 @@ describe Taxjar::API::Request do
                             'Host'=>'api.taxjar.com',
                             'User-Agent'=>"TaxjarRubyGem/#{Taxjar::Version.to_s}"}).
           to_return(:status => 200, :body => '{"object": {"id": "3"}}',
-                    :headers => {content_type: 'application/json; charset utf-8'})
+                    :headers => {content_type: 'application/json; charset=UTF-8'})
 
 
         expect(subject.perform).to eq({id: '3'})
@@ -118,11 +118,11 @@ describe Taxjar::API::Request do
          stub_request(:post, "https://api.taxjar.com/api_path").
                     with(:body => "{\"city\":\"New York\"}",
                          :headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
-                                      'Content-Type'=>'application/json',
+                                      'Content-Type'=>'application/json; charset=UTF-8',
                                       'Host'=>'api.taxjar.com',
                                       'User-Agent'=>"TaxjarRubyGem/#{Taxjar::Version.to_s}"}).
           to_return(:status => 200, :body => '{"object": {"id": "3"}}',
-                    :headers => {content_type: 'application/json; charset utf-8'})
+                    :headers => {content_type: 'application/json; charset=UTF-8'})
 
         expect(subject.perform).to eq({id: '3'})
       end
@@ -139,7 +139,7 @@ describe Taxjar::API::Request do
                       :body => '{"error": "Not Acceptable",
                                  "detail": "error explanation",
                                  "status": "'+ status.to_s + '"}',
-                      :headers => {content_type: 'application/json; charset utf-8'})
+                      :headers => {content_type: 'application/json; charset=UTF-8'})
           expect{subject.perform}.to raise_error(exception, 'error explanation')
         end
       end

--- a/taxjar-ruby.gemspec
+++ b/taxjar-ruby.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.0'
 
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency 'http', '~> 1.0.4'
+  spec.add_dependency 'http', '~> 2.2.2'
   spec.add_dependency 'memoizable', '~> 0.4.0'
   spec.add_dependency 'model_attribute', '~> 3.2'
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
This PR updates HTTP (The Gem) to 2.2.2 and bumps the minimum required Ruby version to 2.0. Also fixes a spec and adds Ruby 2.3, 2.4 to Travis.

After merging, we'll release version 2.0.0 of the TaxJar Ruby gem.