### PR TITLE
Address Validation

### DIFF
--- a/lib/taxjar.rb
+++ b/lib/taxjar.rb
@@ -1,4 +1,5 @@
 require "taxjar/base"
+require "taxjar/address"
 require "taxjar/breakdown"
 require "taxjar/breakdown_line_item"
 require "taxjar/category"

--- a/lib/taxjar/address.rb
+++ b/lib/taxjar/address.rb
@@ -1,0 +1,13 @@
+require 'taxjar/base'
+
+module Taxjar
+  class Address < Taxjar::Base
+    extend ModelAttribute
+
+    attribute :country, :string
+    attribute :state,   :string
+    attribute :zip,     :string
+    attribute :city,    :string
+    attribute :street,  :string
+  end
+end

--- a/lib/taxjar/api/api.rb
+++ b/lib/taxjar/api/api.rb
@@ -19,7 +19,11 @@ module Taxjar
     def nexus_regions(options = {})
       perform_get_with_objects("/v2/nexus/regions", 'regions', options, Taxjar::NexusRegion)
     end
-    
+
+    def validate_address(options = {})
+      perform_post_with_objects("/v2/addresses/validate", 'addresses', options, Taxjar::Address)
+    end
+
     def validate(options = {})
       perform_get_with_object("/v2/validation", 'validation', options, Taxjar::Validation)
     end

--- a/lib/taxjar/api/utils.rb
+++ b/lib/taxjar/api/utils.rb
@@ -23,6 +23,10 @@ module Taxjar
         perform_request_with_object(:post, path, object_key, options, klass)
       end
 
+      def perform_post_with_objects(path, object_key, options, klass)
+        perform_request_with_objects(:post, path, object_key, options, klass)
+      end
+
       def perform_put_with_object(path, object_key, options, klass)
         perform_request_with_object(:put, path, object_key, options, klass)
       end

--- a/spec/fixtures/addresses.json
+++ b/spec/fixtures/addresses.json
@@ -1,0 +1,11 @@
+{
+    "addresses": [
+        {
+            "zip": "85297-2176",
+            "street": "3301 S Greenfield Rd",
+            "state": "AZ",
+            "country": "US",
+            "city": "Gilbert"
+        }
+    ]
+}

--- a/spec/fixtures/addresses_multiple.json
+++ b/spec/fixtures/addresses_multiple.json
@@ -1,0 +1,18 @@
+{
+    "addresses": [
+        {
+            "zip": "85007-3646",
+            "street": "1109 S 9th Ave",
+            "state": "AZ",
+            "country": "US",
+            "city": "Phoenix"
+        },
+        {
+            "zip": "85006-2734",
+            "street": "1109 N 9th St",
+            "state": "AZ",
+            "country": "US",
+            "city": "Phoenix"
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds support for TaxJar's address validation beta endpoint via `validate_address`. At this time, address validation is only available for TaxJar Plus customers.