### PR TITLE
Relax HTTP gem version requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ rvm:
  - "2.2"
  - "2.3"
  - "2.4"
+ - "2.5"
+ - "2.6"
 
 script: bundle exec rspec
 
 before_install:
-  - gem install bundler
+ - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+ - gem install bundler -v '< 2'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'yard'
 
 group :test do
   gem 'rspec', '~> 3'
-  gem 'webmock', '~> 3.0.1'
+  gem 'webmock', '>= 3.0.1'
 end
 
 # Specify your gem's dependencies in taxjar-ruby.gemspec

--- a/taxjar-ruby.gemspec
+++ b/taxjar-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0'
 
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency 'http', '~> 2.2'
+  spec.add_dependency 'http', '>= 1.0', '< 5.0'
   spec.add_dependency 'memoizable', '~> 0.4.0'
   spec.add_dependency 'model_attribute', '~> 3.2'
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
This PR resolves #33 by supporting HTTP gem version up to v4.0.3 and down to v1.0.0 based on PR #38. Specs are passing on all versions.