### PR TITLE
Removes reference to model_attribute fork which is no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installing this gem also bundles the following dependencies:
 * [http](https://github.com/httprb/http.rb) - Fast Ruby HTTP client with a chainable API and full streaming support.
 * [addressable](https://github.com/sporkmonger/addressable) - Replacement for the URI implementation that is part of Ruby's standard library. It more closely conforms to the relevant RFCs and adds support for IRIs and URI templates.
 * [memoizable](https://github.com/dkubb/memoizable) - Memoize method return values.
-* [model_attribute](https://github.com/yammer/model_attribute) - Type casted attributes for non-ActiveRecord models. [Forked](https://github.com/taxjar/model_attribute) to handle floats and more types.
+* [model_attribute](https://github.com/yammer/model_attribute) - Type casted attributes for non-ActiveRecord models.
 
 ## Installation
 


### PR DESCRIPTION
We moved back to the main gem in 62408b62 after yammer/model_attribute#10 was merged.

Resolves https://github.com/taxjar/taxjar-ruby/issues/42.