### PR TITLE
Added support for setting a proxy

### DIFF
--- a/lib/taxjar/api/request.rb
+++ b/lib/taxjar/api/request.rb
@@ -27,13 +27,18 @@ module Taxjar
 
       def perform
         options_key = @request_method == :get ? :params : :json
-        response = HTTP.timeout(@http_timeout).headers(headers)
-          .request(request_method, uri.to_s, options_key => @options)
+        response = build_http_client.request(request_method, uri.to_s, options_key => @options)
         response_body = symbolize_keys!(response.parse)
         fail_or_return_response_body(response.code, response_body)
       end
 
       private
+
+        def build_http_client
+          http_client = HTTP.timeout(@http_timeout).headers(headers)
+          http_client = http_client.via(*client.http_proxy) if client.http_proxy
+          http_client
+        end
 
         def set_request_headers(custom_headers = {})
           @headers = {}

--- a/lib/taxjar/client.rb
+++ b/lib/taxjar/client.rb
@@ -16,6 +16,7 @@ module Taxjar
     attr_accessor :api_key
     attr_accessor :api_url
     attr_accessor :headers
+    attr_accessor :http_proxy
 
     def initialize(options = {})
       options.each do |key, value|

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -119,6 +119,21 @@ describe Taxjar::API::Request do
       Taxjar::API::Request.new(client, :get, '/api_path', 'object')
     end
 
+    context 'with a proxy' do
+      let(:client){ Taxjar::Client.new(api_key: 'AK', http_proxy: ["127.0.0.1", 8080])}
+      it "runs through the proxy" do
+        stub_request(:get, "https://api.taxjar.com/api_path").
+          with(:headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
+                            'Host'=>'api.taxjar.com',
+                            'User-Agent'=>"TaxjarRubyGem/#{Taxjar::Version.to_s}"}).
+          to_return(:status => 200, :body => '{"object": {"id": "3"}}',
+                    :headers => {content_type: 'application/json; charset=UTF-8'})
+
+        expect(subject.perform).to eq({id: '3'})
+        expect(subject.send(:build_http_client).default_options.proxy).to eq({proxy_address: "127.0.0.1", proxy_port: 8080})
+      end
+    end
+
     context 'with get' do
       it 'should return a body if no errors' do
         stub_request(:get, "https://api.taxjar.com/api_path").


### PR DESCRIPTION
Hello! We needed support for sending requests through a proxy, which we can't do as-is, so I added support for it.

WebMock doesn't support asserting that a request was made via a proxy (https://github.com/bblimke/webmock/issues/753), so instead we confirm the request worked normally and then verify the proxy config manually.