### PR TITLE
Add `provider` param to transaction methods

### DIFF
--- a/lib/taxjar/api/request.rb
+++ b/lib/taxjar/api/request.rb
@@ -26,7 +26,7 @@ module Taxjar
       end
 
       def perform
-        options_key = @request_method == :get ? :params : :json
+        options_key = [:get, :delete].include?(@request_method) ? :params : :json
         response = HTTP.timeout(@http_timeout).headers(headers)
           .request(request_method, uri.to_s, options_key => @options)
         response_body = symbolize_keys!(response.parse)

--- a/lib/taxjar/order.rb
+++ b/lib/taxjar/order.rb
@@ -3,10 +3,11 @@ require 'taxjar/base'
 module Taxjar
   class Order < Taxjar::Base
     extend ModelAttribute
-    
+
     attribute :transaction_id,   :string
     attribute :user_id,          :integer
     attribute :transaction_date, :string
+    attribute :provider,         :string
     attribute :from_country,     :string
     attribute :from_zip,         :string
     attribute :from_state,       :string

--- a/lib/taxjar/refund.rb
+++ b/lib/taxjar/refund.rb
@@ -3,11 +3,12 @@ require 'taxjar/base'
 module Taxjar
   class Refund < Taxjar::Base
     extend ModelAttribute
-    
+
     attribute :transaction_id,           :string
     attribute :user_id,                  :integer
     attribute :transaction_date,         :string
     attribute :transaction_reference_id, :string
+    attribute :provider,                 :string
     attribute :from_country,             :string
     attribute :from_zip,                 :string
     attribute :from_state,               :string

--- a/spec/fixtures/order.json
+++ b/spec/fixtures/order.json
@@ -3,6 +3,7 @@
     "transaction_id": "123",
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
+    "provider": "api",
     "from_country": "US",
     "from_zip": "93107",
     "from_state": "CA",

--- a/spec/fixtures/refund.json
+++ b/spec/fixtures/refund.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
     "transaction_reference_id": "123",
+    "provider": "api",
     "from_country": "US",
     "from_zip": "93107",
     "from_state": "CA",

--- a/spec/taxjar/api/order_spec.rb
+++ b/spec/taxjar/api/order_spec.rb
@@ -28,7 +28,7 @@ describe Taxjar::API::Order do
 
     context "with parameters" do
       before do
-        stub_get('/v2/transactions/orders?from_transaction_date=2015/05/01&to_transaction_date=2015/05/31').
+        stub_get('/v2/transactions/orders?from_transaction_date=2015/05/01&to_transaction_date=2015/05/31&provider=api').
           to_return(body: fixture('orders.json'),
                     headers: {content_type: 'application/json; charset=utf-8'})
 
@@ -36,13 +36,15 @@ describe Taxjar::API::Order do
 
       it 'requests the right resource' do
         @client.list_orders(from_transaction_date: '2015/05/01',
-                                     to_transaction_date: '2015/05/31')
-        expect(a_get('/v2/transactions/orders?from_transaction_date=2015/05/01&to_transaction_date=2015/05/31')).to have_been_made
+                            to_transaction_date: '2015/05/31',
+                            provider: 'api')
+        expect(a_get('/v2/transactions/orders?from_transaction_date=2015/05/01&to_transaction_date=2015/05/31&provider=api')).to have_been_made
       end
 
       it 'returns the requested orders' do
         orders = @client.list_orders(from_transaction_date: '2015/05/01',
-                                     to_transaction_date: '2015/05/31')
+                                     to_transaction_date: '2015/05/31',
+                                     provider: 'api')
         expect(orders).to be_an Array
         expect(orders.first).to be_a String
         expect(orders.first).to eq('123')
@@ -52,22 +54,23 @@ describe Taxjar::API::Order do
 
   describe "#show_order" do
     before do
-        stub_get('/v2/transactions/orders/123').
+        stub_get('/v2/transactions/orders/123?provider=api').
           to_return(body: fixture('order.json'),
                     headers: {content_type: 'application/json; charset=utf-8'})
     end
 
     it 'requests the right resource' do
-      @client.show_order('123')
-      expect(a_get('/v2/transactions/orders/123')).to have_been_made
+      @client.show_order('123', provider: 'api')
+      expect(a_get('/v2/transactions/orders/123?provider=api')).to have_been_made
     end
 
     it 'returns the requested order' do
-      order = @client.show_order('123')
+      order = @client.show_order('123', provider: 'api')
       expect(order).to be_an Taxjar::Order
       expect(order.transaction_id).to eq('123')
       expect(order.user_id).to eq(10649)
       expect(order.transaction_date).to eq('2015-05-14T00:00:00Z')
+      expect(order.provider).to eq('api')
       expect(order.from_country).to eq('US')
       expect(order.from_zip).to eq('93107')
       expect(order.from_state).to eq('CA')
@@ -84,7 +87,7 @@ describe Taxjar::API::Order do
     end
 
     it 'allows access to line_items' do
-      order = @client.show_order('123')
+      order = @client.show_order('123', provider: 'api')
       expect(order.line_items[0].id).to eq('1')
       expect(order.line_items[0].quantity).to eq(1)
       expect(order.line_items[0].product_identifier).to eq('12-34243-9')
@@ -103,6 +106,7 @@ describe Taxjar::API::Order do
 
       @order = {:transaction_id => '123',
                 :transaction_date => '2015/05/14',
+                :provider => 'api',
                 :to_country => 'US',
                 :to_zip => '90002',
                 :to_city => 'Los Angeles',
@@ -132,6 +136,7 @@ describe Taxjar::API::Order do
       expect(order.transaction_id).to eq('123')
       expect(order.user_id).to eq(10649)
       expect(order.transaction_date).to eq("2015-05-14T00:00:00Z")
+      expect(order.provider).to eq('api')
       expect(order.from_country).to eq('US')
       expect(order.from_zip).to eq('93107')
       expect(order.from_state).to eq('CA')
@@ -146,7 +151,7 @@ describe Taxjar::API::Order do
       expect(order.shipping).to eq(1.5)
       expect(order.sales_tax).to eq(0.95)
     end
-    
+
     it 'allows access to line_items' do
       order = @client.create_order(@order)
       expect(order.line_items[0].id).to eq('1')
@@ -191,6 +196,7 @@ describe Taxjar::API::Order do
       expect(order.transaction_id).to eq('123')
       expect(order.user_id).to eq(10649)
       expect(order.transaction_date).to eq("2015-05-14T00:00:00Z")
+      expect(order.provider).to eq('api')
       expect(order.from_country).to eq('US')
       expect(order.from_zip).to eq('93107')
       expect(order.from_state).to eq('CA')
@@ -205,7 +211,7 @@ describe Taxjar::API::Order do
       expect(order.shipping).to eq(1.5)
       expect(order.sales_tax).to eq(0.95)
     end
-    
+
     it 'allows access to line_items' do
       order = @client.update_order(@order)
       expect(order.line_items[0].id).to eq('1')
@@ -221,22 +227,23 @@ describe Taxjar::API::Order do
 
   describe "#delete_order" do
     before do
-        stub_delete('/v2/transactions/orders/123').
+        stub_delete('/v2/transactions/orders/123?provider=api').
           to_return(body: fixture('order.json'),
                     headers: {content_type: 'application/json; charset=utf-8'})
     end
 
     it 'requests the right resource' do
-      @client.delete_order('123')
-      expect(a_delete('/v2/transactions/orders/123')).to have_been_made
+      @client.delete_order('123', provider: 'api')
+      expect(a_delete('/v2/transactions/orders/123?provider=api')).to have_been_made
     end
 
     it 'returns the deleted order' do
-      order = @client.delete_order('123')
+      order = @client.delete_order('123', provider: 'api')
       expect(order).to be_an Taxjar::Order
       expect(order.transaction_id).to eq('123')
       expect(order.user_id).to eq(10649)
       expect(order.transaction_date).to eq("2015-05-14T00:00:00Z")
+      expect(order.provider).to eq('api')
       expect(order.from_country).to eq('US')
       expect(order.from_zip).to eq('93107')
       expect(order.from_state).to eq('CA')
@@ -251,9 +258,9 @@ describe Taxjar::API::Order do
       expect(order.shipping).to eq(1.5)
       expect(order.sales_tax).to eq(0.95)
     end
-    
+
     it 'allows access to line items' do
-      order = @client.delete_order('123')
+      order = @client.delete_order('123', provider: 'api')
       expect(order.line_items[0].id).to eq('1')
       expect(order.line_items[0].quantity).to eq(1)
       expect(order.line_items[0].product_identifier).to eq('12-34243-9')

--- a/spec/taxjar/api/refund_spec.rb
+++ b/spec/taxjar/api/refund_spec.rb
@@ -28,7 +28,7 @@ describe Taxjar::API::Refund do
 
     context "with parameters" do
       before do
-        stub_get('/v2/transactions/refunds?from_transaction_date=2015/05/01&to_transaction_date=2015/05/31').
+        stub_get('/v2/transactions/refunds?from_transaction_date=2015/05/01&to_transaction_date=2015/05/31&provider=api').
           to_return(body: fixture('refunds.json'),
                     headers: {content_type: 'application/json; charset=utf-8'})
 
@@ -36,13 +36,15 @@ describe Taxjar::API::Refund do
 
       it 'requests the right resource' do
         @client.list_refunds(from_transaction_date: '2015/05/01',
-                                     to_transaction_date: '2015/05/31')
-        expect(a_get('/v2/transactions/refunds?from_transaction_date=2015/05/01&to_transaction_date=2015/05/31')).to have_been_made
+                             to_transaction_date: '2015/05/31',
+                             provider: 'api')
+        expect(a_get('/v2/transactions/refunds?from_transaction_date=2015/05/01&to_transaction_date=2015/05/31&provider=api')).to have_been_made
       end
 
       it 'returns the requested refunds' do
         refunds = @client.list_refunds(from_transaction_date: '2015/05/01',
-                                     to_transaction_date: '2015/05/31')
+                                       to_transaction_date: '2015/05/31',
+                                       provider: 'api')
         expect(refunds).to be_an Array
         expect(refunds.first).to be_a String
         expect(refunds.first).to eq('321')
@@ -52,23 +54,24 @@ describe Taxjar::API::Refund do
 
   describe "#show_refund" do
     before do
-        stub_get('/v2/transactions/refunds/321').
+        stub_get('/v2/transactions/refunds/321?provider=api').
           to_return(body: fixture('refund.json'),
                     headers: {content_type: 'application/json; charset=utf-8'})
     end
 
     it 'requests the right resource' do
-      @client.show_refund('321')
-      expect(a_get('/v2/transactions/refunds/321')).to have_been_made
+      @client.show_refund('321', provider: 'api')
+      expect(a_get('/v2/transactions/refunds/321?provider=api')).to have_been_made
     end
 
     it 'returns the requested refund' do
-      refund = @client.show_refund('321')
+      refund = @client.show_refund('321', provider: 'api')
       expect(refund).to be_an Taxjar::Refund
       expect(refund.transaction_id).to eq('321')
       expect(refund.user_id).to eq(10649)
       expect(refund.transaction_date).to eq("2015-05-14T00:00:00Z")
       expect(refund.transaction_reference_id).to eq("123")
+      expect(refund.provider).to eql('api')
       expect(refund.from_country).to eq('US')
       expect(refund.from_zip).to eq('93107')
       expect(refund.from_state).to eq('CA')
@@ -83,9 +86,9 @@ describe Taxjar::API::Refund do
       expect(refund.shipping).to eq(1.5)
       expect(refund.sales_tax).to eq(0.95)
     end
-    
+
     it 'allows access to line_items' do
-      refund = @client.show_refund('321')
+      refund = @client.show_refund('321', provider: 'api')
       expect(refund.line_items[0].id).to eq('1')
       expect(refund.line_items[0].quantity).to eq(1)
       expect(refund.line_items[0].product_identifier).to eq('12-34243-9')
@@ -105,6 +108,7 @@ describe Taxjar::API::Refund do
       @refund = {:transaction_id => '321',
                 :transaction_date => '2015/05/14',
                 :transaction_reference_id => '123',
+                :provider => 'api',
                 :to_country => 'US',
                 :to_zip => '90002',
                 :to_state => 'CA',
@@ -135,6 +139,7 @@ describe Taxjar::API::Refund do
       expect(refund.user_id).to eq(10649)
       expect(refund.transaction_date).to eq("2015-05-14T00:00:00Z")
       expect(refund.transaction_reference_id).to eq("123")
+      expect(refund.provider).to eq('api')
       expect(refund.from_country).to eq('US')
       expect(refund.from_zip).to eq('93107')
       expect(refund.from_state).to eq('CA')
@@ -149,7 +154,7 @@ describe Taxjar::API::Refund do
       expect(refund.shipping).to eq(1.5)
       expect(refund.sales_tax).to eq(0.95)
     end
-    
+
     it 'allows access to line_items' do
       refund = @client.create_refund(@refund)
       expect(refund.line_items[0].id).to eq('1')
@@ -195,6 +200,7 @@ describe Taxjar::API::Refund do
       expect(refund.user_id).to eq(10649)
       expect(refund.transaction_date).to eq("2015-05-14T00:00:00Z")
       expect(refund.transaction_reference_id).to eq("123")
+      expect(refund.provider).to eq('api')
       expect(refund.from_country).to eq('US')
       expect(refund.from_zip).to eq('93107')
       expect(refund.from_state).to eq('CA')
@@ -209,7 +215,7 @@ describe Taxjar::API::Refund do
       expect(refund.shipping).to eq(1.5)
       expect(refund.sales_tax).to eq(0.95)
     end
-    
+
     it 'allows access to line_items' do
       refund = @client.update_refund(@refund)
       expect(refund.line_items[0].id).to eq('1')
@@ -225,23 +231,24 @@ describe Taxjar::API::Refund do
 
   describe "#delete_refund" do
     before do
-        stub_delete('/v2/transactions/refunds/321').
+        stub_delete('/v2/transactions/refunds/321?provider=api').
           to_return(body: fixture('refund.json'),
                     headers: {content_type: 'application/json; charset=utf-8'})
     end
 
     it 'requests the right resource' do
-      @client.delete_refund('321')
-      expect(a_delete('/v2/transactions/refunds/321')).to have_been_made
+      @client.delete_refund('321', provider: 'api')
+      expect(a_delete('/v2/transactions/refunds/321?provider=api')).to have_been_made
     end
 
-    it 'returns the delete refund' do
-      refund = @client.delete_refund('321')
+    it 'returns the deleted refund' do
+      refund = @client.delete_refund('321', provider: 'api')
       expect(refund).to be_an Taxjar::Refund
       expect(refund.transaction_id).to eq('321')
       expect(refund.user_id).to eq(10649)
       expect(refund.transaction_date).to eq("2015-05-14T00:00:00Z")
       expect(refund.transaction_reference_id).to eq("123")
+      expect(refund.provider).to eq('api')
       expect(refund.from_country).to eq('US')
       expect(refund.from_zip).to eq('93107')
       expect(refund.from_state).to eq('CA')
@@ -256,9 +263,9 @@ describe Taxjar::API::Refund do
       expect(refund.shipping).to eq(1.5)
       expect(refund.sales_tax).to eq(0.95)
     end
-    
+
     it 'allows access to line_items' do
-      refund = @client.delete_refund('321')
+      refund = @client.delete_refund('321', provider: 'api')
       expect(refund.line_items[0].id).to eq('1')
       expect(refund.line_items[0].quantity).to eq(1)
       expect(refund.line_items[0].product_identifier).to eq('12-34243-9')


### PR DESCRIPTION
This PR implements the new `provider` param, which currently adds marketplace exemption support for Amazon, eBay, Etsy, and Walmart transactions. `provider` defaults to `api`.

The `provider` param will be supported in methods:

- `list_orders`
- `show_order`
- `create_order`
- `delete_order`
- `list_refunds`
- `show_refund`
- `create_refund`
- `delete_refund`