### PR TITLE
Add support for order-level exemptions via `exemption_type` param

### DIFF
--- a/lib/taxjar/order.rb
+++ b/lib/taxjar/order.rb
@@ -8,6 +8,7 @@ module Taxjar
     attribute :user_id,          :integer
     attribute :transaction_date, :string
     attribute :provider,         :string
+    attribute :exemption_type,   :string
     attribute :from_country,     :string
     attribute :from_zip,         :string
     attribute :from_state,       :string

--- a/lib/taxjar/refund.rb
+++ b/lib/taxjar/refund.rb
@@ -9,6 +9,7 @@ module Taxjar
     attribute :transaction_date,         :string
     attribute :transaction_reference_id, :string
     attribute :provider,                 :string
+    attribute :exemption_type,           :string
     attribute :from_country,             :string
     attribute :from_zip,                 :string
     attribute :from_state,               :string

--- a/lib/taxjar/tax.rb
+++ b/lib/taxjar/tax.rb
@@ -12,6 +12,7 @@ module Taxjar
     attribute :has_nexus,          :boolean
     attribute :freight_taxable,    :boolean
     attribute :tax_source,         :string
+    attribute :exemption_type,     :string
 
     object_attr_reader Taxjar::Jurisdictions, :jurisdictions
     object_attr_reader Taxjar::Breakdown, :breakdown

--- a/spec/fixtures/order.json
+++ b/spec/fixtures/order.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
     "provider": "api",
+    "exemption_type": "non_exempt",
     "from_country": "US",
     "from_zip": "93107",
     "from_state": "CA",

--- a/spec/fixtures/refund.json
+++ b/spec/fixtures/refund.json
@@ -5,6 +5,7 @@
     "transaction_date": "2015-05-14T00:00:00Z",
     "transaction_reference_id": "123",
     "provider": "api",
+    "exemption_type": "non_exempt",
     "from_country": "US",
     "from_zip": "93107",
     "from_state": "CA",

--- a/spec/fixtures/taxes.json
+++ b/spec/fixtures/taxes.json
@@ -8,6 +8,7 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "exemption_type": "non_exempt",
     "jurisdictions": {
       "country": "US",
       "state": "NJ",

--- a/spec/fixtures/taxes_canada.json
+++ b/spec/fixtures/taxes_canada.json
@@ -8,6 +8,7 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "exemption_type": "non_exempt",
     "jurisdictions": {
       "country": "CA",
       "state": "ON"

--- a/spec/fixtures/taxes_international.json
+++ b/spec/fixtures/taxes_international.json
@@ -8,6 +8,7 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "exemption_type": "non_exempt",
     "jurisdictions": {
       "country": "FI"
     },

--- a/spec/taxjar/api/api_spec.rb
+++ b/spec/taxjar/api/api_spec.rb
@@ -168,6 +168,7 @@ describe Taxjar::API do
                 :to_zip => '07446',
                 :amount => 16.50,
                 :shipping => 1.5,
+                :exemption_type => 'non_exempt',
                 :line_items => [{:line_item => {:id => '1',
                                                 :quantity => 1,
                                                 :unit_price => 15.0,
@@ -191,6 +192,7 @@ describe Taxjar::API do
       expect(tax.has_nexus).to eq(true)
       expect(tax.freight_taxable).to eq(true)
       expect(tax.tax_source).to eq('destination')
+      expect(tax.exemption_type).to eq('non_exempt')
     end
 
     it 'allows access to jurisdictions' do
@@ -275,6 +277,7 @@ describe Taxjar::API do
         expect(tax.has_nexus).to eq(true)
         expect(tax.freight_taxable).to eq(true)
         expect(tax.tax_source).to eq('destination')
+        expect(tax.exemption_type).to eq('non_exempt')
       end
 
       it 'allows access to jurisdictions' do
@@ -330,6 +333,7 @@ describe Taxjar::API do
         expect(tax.has_nexus).to eq(true)
         expect(tax.freight_taxable).to eq(true)
         expect(tax.tax_source).to eq('destination')
+        expect(tax.exemption_type).to eq('non_exempt')
       end
 
       it 'allows access to jurisdictions' do

--- a/spec/taxjar/api/order_spec.rb
+++ b/spec/taxjar/api/order_spec.rb
@@ -71,6 +71,7 @@ describe Taxjar::API::Order do
       expect(order.user_id).to eq(10649)
       expect(order.transaction_date).to eq('2015-05-14T00:00:00Z')
       expect(order.provider).to eq('api')
+      expect(order.exemption_type).to eq('non_exempt')
       expect(order.from_country).to eq('US')
       expect(order.from_zip).to eq('93107')
       expect(order.from_state).to eq('CA')
@@ -107,6 +108,7 @@ describe Taxjar::API::Order do
       @order = {:transaction_id => '123',
                 :transaction_date => '2015/05/14',
                 :provider => 'api',
+                :exemption_type => 'non_exempt',
                 :to_country => 'US',
                 :to_zip => '90002',
                 :to_city => 'Los Angeles',
@@ -137,6 +139,7 @@ describe Taxjar::API::Order do
       expect(order.user_id).to eq(10649)
       expect(order.transaction_date).to eq("2015-05-14T00:00:00Z")
       expect(order.provider).to eq('api')
+      expect(order.exemption_type).to eq('non_exempt')
       expect(order.from_country).to eq('US')
       expect(order.from_zip).to eq('93107')
       expect(order.from_state).to eq('CA')
@@ -174,6 +177,7 @@ describe Taxjar::API::Order do
       @order = {:transaction_id => '123',
                 :amount => 17.95,
                 :shipping => 2.0,
+                :exemption_type => 'non_exempt',
                 :line_items => [{:id => 1,
                                  :quantity => 1,
                                  :product_identifier => '12-34243-0',
@@ -197,6 +201,7 @@ describe Taxjar::API::Order do
       expect(order.user_id).to eq(10649)
       expect(order.transaction_date).to eq("2015-05-14T00:00:00Z")
       expect(order.provider).to eq('api')
+      expect(order.exemption_type).to eq('non_exempt')
       expect(order.from_country).to eq('US')
       expect(order.from_zip).to eq('93107')
       expect(order.from_state).to eq('CA')
@@ -244,6 +249,7 @@ describe Taxjar::API::Order do
       expect(order.user_id).to eq(10649)
       expect(order.transaction_date).to eq("2015-05-14T00:00:00Z")
       expect(order.provider).to eq('api')
+      expect(order.exemption_type).to eq('non_exempt')
       expect(order.from_country).to eq('US')
       expect(order.from_zip).to eq('93107')
       expect(order.from_state).to eq('CA')

--- a/spec/taxjar/api/refund_spec.rb
+++ b/spec/taxjar/api/refund_spec.rb
@@ -72,6 +72,7 @@ describe Taxjar::API::Refund do
       expect(refund.transaction_date).to eq("2015-05-14T00:00:00Z")
       expect(refund.transaction_reference_id).to eq("123")
       expect(refund.provider).to eql('api')
+      expect(refund.exemption_type).to eq('non_exempt')
       expect(refund.from_country).to eq('US')
       expect(refund.from_zip).to eq('93107')
       expect(refund.from_state).to eq('CA')
@@ -109,6 +110,7 @@ describe Taxjar::API::Refund do
                 :transaction_date => '2015/05/14',
                 :transaction_reference_id => '123',
                 :provider => 'api',
+                :exemption_type => 'non_exempt',
                 :to_country => 'US',
                 :to_zip => '90002',
                 :to_state => 'CA',
@@ -140,6 +142,7 @@ describe Taxjar::API::Refund do
       expect(refund.transaction_date).to eq("2015-05-14T00:00:00Z")
       expect(refund.transaction_reference_id).to eq("123")
       expect(refund.provider).to eq('api')
+      expect(refund.exemption_type).to eq('non_exempt')
       expect(refund.from_country).to eq('US')
       expect(refund.from_zip).to eq('93107')
       expect(refund.from_state).to eq('CA')
@@ -178,6 +181,7 @@ describe Taxjar::API::Refund do
                 :amount => 17.95,
                 :shipping => 2.0,
                 :sales_tax => 0.95,
+                :exemption_type => 'non_exempt',
                 :line_items => [{:quantity => 1,
                                  :product_identifier => '12-34243-9',
                                  :description => 'Heavy Widget',
@@ -201,6 +205,7 @@ describe Taxjar::API::Refund do
       expect(refund.transaction_date).to eq("2015-05-14T00:00:00Z")
       expect(refund.transaction_reference_id).to eq("123")
       expect(refund.provider).to eq('api')
+      expect(refund.exemption_type).to eq('non_exempt')
       expect(refund.from_country).to eq('US')
       expect(refund.from_zip).to eq('93107')
       expect(refund.from_state).to eq('CA')
@@ -249,6 +254,7 @@ describe Taxjar::API::Refund do
       expect(refund.transaction_date).to eq("2015-05-14T00:00:00Z")
       expect(refund.transaction_reference_id).to eq("123")
       expect(refund.provider).to eq('api')
+      expect(refund.exemption_type).to eq('non_exempt')
       expect(refund.from_country).to eq('US')
       expect(refund.from_zip).to eq('93107')
       expect(refund.from_state).to eq('CA')


### PR DESCRIPTION
This change introduces an optional `exemption_type` parameter for:

- tax_for_order
- create_order
- update_order
- create_refund
- update_refund

The allowable values are: `government`, `wholesale`, `other`, and `non_exempt`.

With the exception of `non_exempt`, a request with one of these values indicates a transaction that is fully-exempt at the order level.

When also using the existing optional `customer_id` parameter, an `exemption_type` value of `non_exempt` specifies that a transaction belonging to an otherwise exempt customer be processed as taxable.

With the exception of `non_exempt`, when usage of the `customer_id` param qualifies the transaction as exempt, the customer's exemption type would be applied, rather than the `exemption_type` submitted in the request.