### PR TITLE
Allow setting up HTTP logger

### DIFF
--- a/lib/taxjar/api/request.rb
+++ b/lib/taxjar/api/request.rb
@@ -7,6 +7,10 @@ module Taxjar
       DEFAULT_API_URL = 'https://api.taxjar.com'
       SANDBOX_API_URL = 'https://api.sandbox.taxjar.com'
 
+      class << self
+        attr_accessor :logger
+      end
+
       attr_reader :client, :uri, :headers, :request_method, :path, :object_key, :options
 
       # @param client [Taxjar::Client]
@@ -37,7 +41,12 @@ module Taxjar
         def build_http_client
           http_client = HTTP.timeout(@http_timeout).headers(headers)
           http_client = http_client.via(*client.http_proxy) if client.http_proxy
-          http_client
+
+          if self.class.logger
+            http_client.use(logging: { logger: self.class.logger })
+          else
+            http_client
+          end
         end
 
         def set_request_headers(custom_headers = {})

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -209,13 +209,27 @@ describe Taxjar::API::Request do
         described_class.logger = nil
       end
 
-      it 'logs  both request and response' do
-        subject.perform
-        expect(logger).to have_received(:info)
-        expect(logger).to have_received(:debug)
+      if HTTP::Options.available_features.key?(:logging)
+        context 'when HTTP logging supported' do
+          it 'logs both request and response' do
+            allow(described_class).to receive(:http_logger_supported?).and_return(true)
+            subject.perform
+            expect(logger).to have_received(:info)
+            expect(logger).to have_received(:debug)
 
-        expect(logger).to have_received(:info)
-        expect(logger).to have_received(:debug)
+            expect(logger).to have_received(:info)
+            expect(logger).to have_received(:debug)
+          end
+        end
+      end
+
+      context 'when HTTP logging is unsupported' do
+        it "doesn't use the provided logger" do
+          allow(described_class).to receive(:http_logger_supported?).and_return(false)
+          subject.perform
+          expect(logger).not_to have_received(:info)
+          expect(logger).not_to have_received(:debug)
+        end
       end
     end
 


### PR DESCRIPTION
I believe it could be useful to allow logging all HTTP requests done with the gem.

It would allow customers to have a detailed audit/transactions log. Use cases include
- instrumenting the number of API calls
- debugging payload data
- monitoring API latency

Any thoughts, concerns?