### PR TITLE
Add better error handling for non-JSON responses

### DIFF
--- a/lib/taxjar/error.rb
+++ b/lib/taxjar/error.rb
@@ -61,6 +61,10 @@ module Taxjar
         new(message, code)
       end
 
+      def for_json_parse_error(code)
+        ServerError.new("Couldn't parse response as JSON.", code)
+      end
+
     end
 
     def initialize(message = '', code = nil)

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -168,6 +168,17 @@ describe Taxjar::API::Request do
       end
     end
 
+    it 'handles unexpected Content-Type responses' do
+      stub_request(:get, "https://api.taxjar.com/api_path").
+        with(:headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
+                          'Host'=>'api.taxjar.com',
+                          'User-Agent'=>"TaxjarRubyGem/#{Taxjar::Version.to_s}"}).
+        to_return(:status => 200, :body => 'Something unexpected',
+                  :headers => {content_type: 'text/html; charset=UTF-8'})
+
+      expect{subject.perform}.to raise_error(Taxjar::Error::ServerError)
+    end
+
     Taxjar::Error::ERRORS.each do |status, exception|
       context "when HTTP status is #{status}" do
         it "raises #{exception}" do


### PR DESCRIPTION
This closes #50 by asking the HTTP library to explicitly parse the response as JSON. If that fails, we get a specific error type, `JSON::ParserError`. We then turn that into a `Taxjar::Error::ServerError`.

In some cases, the TaxJar API is returning HTML with the `Content-Type text/html` and that causes this library to fail with a generic error from the http-ruby library. With this change, we will have a specific error that is namespaced by `Taxjar`.