### PR TITLE
Add more information to custom user agent string

### DIFF
--- a/lib/taxjar/client.rb
+++ b/lib/taxjar/client.rb
@@ -38,7 +38,14 @@ module Taxjar
     end
 
     def user_agent
-      "TaxjarRubyGem/#{Taxjar::Version}"
+      def platform
+        (`uname -a` || '').strip
+      rescue Errno::ENOENT, Errno::ENOMEM
+        ''
+      end
+      ruby_version = "ruby #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
+      openSSL_version = OpenSSL::OPENSSL_LIBRARY_VERSION
+      "TaxJar/Ruby (#{platform}; #{ruby_version}; #{openSSL_version}) taxjar-ruby/#{Taxjar::Version}"
     end
   end
 end

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -41,7 +41,7 @@ describe Taxjar::API::Request do
     it 'should return headers' do
       expect(subject).to respond_to(:headers)
       expect(subject.headers).to be_instance_of(Hash)
-      expect(subject.headers[:user_agent]).to match('TaxjarRubyGem')
+      expect(subject.headers[:user_agent]).to match(/^TaxJar\/Ruby \(.+\) taxjar-ruby\/\d+\.\d+\.\d+$/)
       expect(subject.headers[:authorization]).to eq('Bearer AK')
     end
 
@@ -52,7 +52,7 @@ describe Taxjar::API::Request do
       subject = Taxjar::API::Request.new(client, :get, '/api_path', 'object')
       expect(subject).to respond_to(:headers)
       expect(subject.headers).to be_instance_of(Hash)
-      expect(subject.headers[:user_agent]).to match('TaxjarRubyGem')
+      expect(subject.headers[:user_agent]).to match(/^TaxJar\/Ruby \(.+\) taxjar-ruby\/\d+\.\d+\.\d+$/)
       expect(subject.headers[:authorization]).to eq('Bearer AK')
       expect(subject.headers['X-TJ-Expected-Response']).to eq(422)
     end
@@ -124,8 +124,7 @@ describe Taxjar::API::Request do
       it "runs through the proxy" do
         stub_request(:get, "https://api.taxjar.com/api_path").
           with(:headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
-                            'Host'=>'api.taxjar.com',
-                            'User-Agent'=>"TaxjarRubyGem/#{Taxjar::Version.to_s}"}).
+                            'Host'=>'api.taxjar.com'}).
           to_return(:status => 200, :body => '{"object": {"id": "3"}}',
                     :headers => {content_type: 'application/json; charset=UTF-8'})
 
@@ -138,8 +137,7 @@ describe Taxjar::API::Request do
       it 'should return a body if no errors' do
         stub_request(:get, "https://api.taxjar.com/api_path").
           with(:headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
-                            'Host'=>'api.taxjar.com',
-                            'User-Agent'=>"TaxjarRubyGem/#{Taxjar::Version.to_s}"}).
+                            'Host'=>'api.taxjar.com'}).
           to_return(:status => 200, :body => '{"object": {"id": "3"}}',
                     :headers => {content_type: 'application/json; charset=UTF-8'})
 
@@ -159,8 +157,7 @@ describe Taxjar::API::Request do
                     with(:body => "{\"city\":\"New York\"}",
                          :headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
                                       'Content-Type'=>'application/json; charset=UTF-8',
-                                      'Host'=>'api.taxjar.com',
-                                      'User-Agent'=>"TaxjarRubyGem/#{Taxjar::Version.to_s}"}).
+                                      'Host'=>'api.taxjar.com'}).
           to_return(:status => 200, :body => '{"object": {"id": "3"}}',
                     :headers => {content_type: 'application/json; charset=UTF-8'})
 
@@ -171,8 +168,7 @@ describe Taxjar::API::Request do
     it 'handles unexpected Content-Type responses' do
       stub_request(:get, "https://api.taxjar.com/api_path").
         with(:headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
-                          'Host'=>'api.taxjar.com',
-                          'User-Agent'=>"TaxjarRubyGem/#{Taxjar::Version.to_s}"}).
+                          'Host'=>'api.taxjar.com'}).
         to_return(:status => 200, :body => 'Something unexpected',
                   :headers => {content_type: 'text/html; charset=UTF-8'})
 
@@ -184,8 +180,7 @@ describe Taxjar::API::Request do
         it "raises #{exception}" do
           stub_request(:get, "https://api.taxjar.com/api_path").
             with(:headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
-                              'Host'=>'api.taxjar.com',
-                              'User-Agent'=>"TaxjarRubyGem/#{Taxjar::Version.to_s}"}).
+                              'Host'=>'api.taxjar.com'}).
             to_return(:status => status,
                       :body => '{"error": "Not Acceptable",
                                  "detail": "error explanation",

--- a/spec/taxjar/client_spec.rb
+++ b/spec/taxjar/client_spec.rb
@@ -1,7 +1,7 @@
 require 'helper'
 
 describe Taxjar::Client do
-  describe '#api_key?' do 
+  describe '#api_key?' do
     it 'returns true if api_key is present' do
       client = Taxjar::Client.new(api_key: 'AK')
       expect(client.api_key?).to be true
@@ -25,14 +25,14 @@ describe Taxjar::Client do
       client.set_api_config('api_url', 'https://api.sandbox.taxjar.com')
       expect(client.api_url).to eq('https://api.sandbox.taxjar.com')
     end
-    
+
     it 'sets new custom headers' do
       client = Taxjar::Client.new(api_key: 'AK')
       client.set_api_config('headers', { 'X-TJ-Expected-Response' => 422 })
       expect(client.headers).to eq({ 'X-TJ-Expected-Response' => 422 })
     end
   end
-  
+
   describe "#get_api_config" do
     it 'gets a config value' do
       client = Taxjar::Client.new(api_key: 'AK')
@@ -44,7 +44,7 @@ describe Taxjar::Client do
   describe '#user_agent' do
     it 'returns string with version' do
       client = Taxjar::Client.new(api_key: 'AK')
-      expect(client.user_agent).to eq("TaxjarRubyGem/#{Taxjar::Version}")
+      expect(client.user_agent).to match(/^TaxJar\/Ruby \(.+\) taxjar-ruby\/\d+\.\d+\.\d+$/)
     end
   end
 end


### PR DESCRIPTION
To help debug technical issues, it's necessary to collect additional information about a user's server.

For that purpose, this PR adds a custom user agent string to each request, which includes the following information:

- Operating system
- Ruby version
- OpenSSL version
- Version of taxjar-ruby currently being used

Example UA string:
<img width="964" alt="Screen Shot 2020-03-26 at 7 11 40 PM" src="https://user-images.githubusercontent.com/26824724/77715155-08b4cc00-6f98-11ea-94bc-4edb7415132a.png">


