### PR TITLE
Throws an exception for any non-successful HTTP response.

### DIFF
--- a/lib/taxjar/api/request.rb
+++ b/lib/taxjar/api/request.rb
@@ -80,8 +80,7 @@ module Taxjar
           elsif !(klass = Taxjar::Error::ERRORS[response.code]).nil?
             fail(klass.from_response(body))
           else
-            message = HTTP::Response::Status::REASONS[response.code] || "Unknown Error"
-            fail(Taxjar::Error, message)
+            fail(Taxjar::Error.from_response_code(response.code))
           end
         end
     end

--- a/lib/taxjar/api/request.rb
+++ b/lib/taxjar/api/request.rb
@@ -81,7 +81,7 @@ module Taxjar
             fail(klass.from_response(body))
           else
             message = HTTP::Response::Status::REASONS[response.code] || "Unknown Error"
-            fail(HTTP::Error, message)
+            fail(Taxjar::Error, message)
           end
         end
     end

--- a/lib/taxjar/error.rb
+++ b/lib/taxjar/error.rb
@@ -61,6 +61,11 @@ module Taxjar
         new(message, code)
       end
 
+      def from_response_code(code)
+        message = HTTP::Response::Status::REASONS[code] || "Unknown Error"
+        new(message, code)
+      end
+
       def for_json_parse_error(code)
         ServerError.new("Couldn't parse response as JSON.", code)
       end

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -193,7 +193,7 @@ describe Taxjar::API::Request do
     end
 
     context "when HTTP status is 502" do
-      it "raises HTTP::Error" do
+      it "raises Taxjar::Error" do
         stub_request(:get, "https://api.taxjar.com/api_path").
           with(:headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
                             'Host'=>'api.taxjar.com'}).
@@ -201,12 +201,12 @@ describe Taxjar::API::Request do
                     :body => '{}',
                     :headers => {content_type: 'application/json; charset=UTF-8'})
 
-        expect{subject.perform}.to raise_error(HTTP::Error, "Bad Gateway")
+        expect{subject.perform}.to raise_error(Taxjar::Error, "Bad Gateway")
       end
     end
 
     context "when HTTP status is 5xx" do
-      it "raises HTTP::Error" do
+      it "raises Taxjar::Error" do
         stub_request(:get, "https://api.taxjar.com/api_path").
           with(:headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
                             'Host'=>'api.taxjar.com'}).
@@ -214,7 +214,7 @@ describe Taxjar::API::Request do
                     :body => '{}',
                     :headers => {content_type: 'application/json; charset=UTF-8'})
 
-        expect{subject.perform}.to raise_error(HTTP::Error, "Unknown Error")
+        expect{subject.perform}.to raise_error(Taxjar::Error, "Unknown Error")
       end
     end
   end

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -201,7 +201,12 @@ describe Taxjar::API::Request do
                     :body => '{}',
                     :headers => {content_type: 'application/json; charset=UTF-8'})
 
-        expect{subject.perform}.to raise_error(Taxjar::Error, "Bad Gateway")
+        expect{subject.perform}.to raise_error(
+          an_instance_of(Taxjar::Error).and having_attributes({
+            "message" => "Bad Gateway",
+            "code" => 502
+          })
+        )
       end
     end
 
@@ -214,7 +219,12 @@ describe Taxjar::API::Request do
                     :body => '{}',
                     :headers => {content_type: 'application/json; charset=UTF-8'})
 
-        expect{subject.perform}.to raise_error(Taxjar::Error, "Unknown Error")
+        expect{subject.perform}.to raise_error(
+          an_instance_of(Taxjar::Error).and having_attributes({
+            "message" => "Unknown Error",
+            "code" => 509
+          })
+        )
       end
     end
   end

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -191,5 +191,31 @@ describe Taxjar::API::Request do
         end
       end
     end
+
+    context "when HTTP status is 502" do
+      it "raises HTTP::Error" do
+        stub_request(:get, "https://api.taxjar.com/api_path").
+          with(:headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
+                            'Host'=>'api.taxjar.com'}).
+          to_return(:status => 502,
+                    :body => '{}',
+                    :headers => {content_type: 'application/json; charset=UTF-8'})
+
+        expect{subject.perform}.to raise_error(HTTP::Error, "Bad Gateway")
+      end
+    end
+
+    context "when HTTP status is 5xx" do
+      it "raises HTTP::Error" do
+        stub_request(:get, "https://api.taxjar.com/api_path").
+          with(:headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
+                            'Host'=>'api.taxjar.com'}).
+          to_return(:status => 509,
+                    :body => '{}',
+                    :headers => {content_type: 'application/json; charset=UTF-8'})
+
+        expect{subject.perform}.to raise_error(HTTP::Error, "Unknown Error")
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes #62 by throwing an exception for any non-successful HTTP response.