### PR TITLE
Classifies `HTTP::Error`s as `Taxjar::Error`s

### DIFF
--- a/lib/taxjar/api/request.rb
+++ b/lib/taxjar/api/request.rb
@@ -35,6 +35,8 @@ module Taxjar
             nil
           end
         fail_or_return_response_body(response, response_body)
+      rescue HTTP::Error => e
+        raise Taxjar::Error, e
       end
 
       private

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -175,6 +175,24 @@ describe Taxjar::API::Request do
       expect{subject.perform}.to raise_error(Taxjar::Error::ServerError)
     end
 
+    [
+      HTTP::Error,
+      HTTP::ConnectionError,
+      HTTP::RequestError,
+      HTTP::ResponseError,
+      HTTP::StateError,
+      HTTP::TimeoutError,
+      HTTP::HeaderError
+    ].each do |http_error_class|
+      context "#{http_error_class}" do
+        it "is classified as a Taxjar::Error" do
+          stub_request(:get, "https://api.taxjar.com/api_path").to_raise(http_error_class)
+
+          expect{subject.perform}.to raise_error(Taxjar::Error)
+        end
+      end
+    end
+
     Taxjar::Error::ERRORS.each do |status, exception|
       context "when HTTP status is #{status}" do
         it "raises #{exception}" do


### PR DESCRIPTION
After discussing with @fastdivision, we decided it would be easier on devs if we re-classified `HTTP::ConnectionError` as `Taxjar::Error`. [As per the error handling example](https://github.com/taxjar/taxjar-ruby#error-handling), devs will only need to rescue from one type of error. This PR re-classifies any `HTTP::Error`, as defined here: https://github.com/httprb/http/blob/4-x-stable/lib/http/errors.rb