### PR TITLE
Support request logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Support request logging
+
 ## [3.0.2] - 2021-03-18
 - Re-classify `HTTP::ConnectionError` and other `HTTP::Error` types as `Taxjar::Error`
 

--- a/README.md
+++ b/README.md
@@ -1388,6 +1388,15 @@ rescue Taxjar::Error => e
 end
 ```
 
+## Request Logging
+
+To enable logging, pass an instance of a logger to `Client`. This will be passed to the underlying HTTP client, so these are request logs.
+
+```ruby
+require 'taxjar'
+client = Taxjar::Client.new(api_key: '48ceecccc8af930bd02597aec0f84a78', logger: Logger.new(STDOUT))
+```
+
 ## Tests
 
 An RSpec test suite is available to ensure API functionality:

--- a/lib/taxjar/api/request.rb
+++ b/lib/taxjar/api/request.rb
@@ -43,6 +43,9 @@ module Taxjar
 
         def build_http_client
           http_client = HTTP.timeout(@http_timeout).headers(headers)
+          if client.logger
+            http_client = http_client.use(logging: {logger: client.logger})
+          end
           http_client = http_client.via(*client.http_proxy) if client.http_proxy
           http_client
         end

--- a/lib/taxjar/client.rb
+++ b/lib/taxjar/client.rb
@@ -17,6 +17,7 @@ module Taxjar
     attr_accessor :api_url
     attr_accessor :headers
     attr_accessor :http_proxy
+    attr_accessor :logger
 
     def initialize(options = {})
       options.each do |key, value|

--- a/spec/taxjar/api/request_spec.rb
+++ b/spec/taxjar/api/request_spec.rb
@@ -133,6 +133,25 @@ describe Taxjar::API::Request do
       end
     end
 
+    context 'with logger' do
+      let(:client) { Taxjar::Client.new(api_key: 'AK', logger: logger) }
+      let(:logger) { double }
+
+      before do
+        stub_request(:get, "https://api.taxjar.com/api_path").
+          with(:headers => {'Authorization'=>'Bearer AK', 'Connection'=>'close',
+                            'Host'=>'api.taxjar.com'}).
+          to_return(:status => 200, :body => '{"object": {"id": "3"}}',
+                    :headers => {content_type: 'application/json; charset=UTF-8'})
+      end
+
+      it "calls the logger" do
+        expect(logger).to receive(:info).at_least(:once)
+        expect(logger).to receive(:debug).at_least(:once)
+        subject.perform
+      end
+    end
+
     context 'with get' do
       it 'should return a body if no errors' do
         stub_request(:get, "https://api.taxjar.com/api_path").


### PR DESCRIPTION
TaxJar requires certified extensions to record request logs for
debugging and support purposes. As such we should support request
logging so Ruby TaxJar integrations can become certified.

Co-authored-by: Noah Silvera <noah@super.gd>