### PR TITLE
Fix readme address validation link & logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TaxJar Sales Tax API for Ruby [![RubyGems](https://img.shields.io/gem/v/taxjar-ruby.svg?style=flat-square)](https://rubygems.org/gems/taxjar-ruby) [![Build Status](https://img.shields.io/travis/taxjar/taxjar-ruby.svg?style=flat-square)](https://travis-ci.org/taxjar/taxjar-ruby)
 
-<a href="https://developers.taxjar.com"><img src="https://www.taxjar.com/img/TJ_logo_color_office_png.png" alt="TaxJar" width="220"></a>
+<a href="https://developers.taxjar.com"><img src="https://www.taxjar.com/wp-content/uploads/TaxJar__Wordmark_Black.svg" alt="TaxJar" width="220"></a>
 
 A Ruby interface to the TaxJar [Sales Tax API](https://developers.taxjar.com/api/reference/?ruby). TaxJar makes sales tax filing easier for online sellers and merchants. See local jurisdictional tax reports, get payment reminders, and more. You can use our API to access TaxJar API endpoints, which can get information on sales tax rates, categories or upload transactions.
 

--- a/README.md
+++ b/README.md
@@ -1188,7 +1188,7 @@ nexus_regions = client.nexus_regions
 
 ### Validate an address <small>_([API docs](https://developers.taxjar.com/api/reference/?ruby#post-validate-an-address))_</small>
 
-> Validates a customer address and returns back a collection of address matches. **Address validation requires a [TaxJar Plus](https://www.taxjar.com/plus/) subscription.**
+> Validates a customer address and returns back a collection of address matches. **Address validation requires a [TaxJar Professional](https://www.taxjar.com/pricing) subscription.**
 
 #### Definition
 


### PR DESCRIPTION
Hey,
I just read through the README and found that the logo wasn't displayed properly (the URL is dead). Additionally, I was confused by your mention of a TaxJar Plus subscription in the part about the address validation, which was probably replaced by the Professional subscription.

For the logo it might make sense to include this directly in the repository so that it does not break again. 