### PR TITLE
Bump gem to use http v5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: ruby
 
 rvm:
- - "2.3"
- - "2.4"
- - "2.5"
- - "2.6"
  - "2.7"
  - "3.0"
+ - "3.1"
 
 script: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Update required Ruby version from 2.3 to 2.7 or higher
+- Update HTTP (The Gem) to version 5.x
 
 ## [3.0.3] - 2022-02-07
 - Throw a `Taxjar::Error::GatewayTimeout` exception when receiving a 504 HTTP status code

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A Ruby interface to the TaxJar [Sales Tax API](https://developers.taxjar.com/api
 
 ## Supported Ruby Versions
 
-Ruby 2.3 or greater
+Ruby 2.7 or greater
 
 ## Gem Dependencies
 

--- a/taxjar-ruby.gemspec
+++ b/taxjar-ruby.gemspec
@@ -1,5 +1,6 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'taxjar/version'
 
@@ -8,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.version       = Taxjar::Version
   spec.authors       = ["TaxJar"]
   spec.email         = ["support@taxjar.com"]
-  spec.summary       = %q{Ruby wrapper for Taxjar API}
-  spec.description   = %q{Ruby wrapper for Taxjar API, more info at developers.taxjar.com}
+  spec.summary       = "Ruby wrapper for Taxjar API"
+  spec.description   = "Ruby wrapper for Taxjar API, more info at developers.taxjar.com"
   spec.homepage      = "http://developers.taxjar.com"
   spec.license       = "MIT"
 
@@ -18,14 +19,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency 'http', '>= 4.3', '< 5.0'
+  spec.add_dependency 'http', '~> 5.0'
   spec.add_dependency 'memoizable', '~> 0.4.0'
   spec.add_dependency 'model_attribute', '~> 3.2'
   spec.add_development_dependency "bundler", ">= 1.7", "< 3.0"
-  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "rake", "~> 13.0"
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = 'https://github.com/taxjar/taxjar-ruby/blob/master/CHANGELOG.md'


### PR DESCRIPTION
## What does this PR do?
* Upgrades `http` to `5.x`
* Upgrades `rake` to `13.0`
* Drop support for ruby versions that are EOL (`2.3, 2.4, 2.5, 2.6`)

### Related issues
  - https://github.com/taxjar/taxjar-ruby/issues/76
