### PR TITLE
Relaxes http version to allow >= 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ rvm:
  - "2.6"
  - "2.7"
  - "3.0"
+ - "3.1"
 
 script: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Relaxes `http` version to allow >= 5
 
 ## [3.0.3] - 2022-02-07
 - Throw a `Taxjar::Error::GatewayTimeout` exception when receiving a 504 HTTP status code

--- a/taxjar-ruby.gemspec
+++ b/taxjar-ruby.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency 'http', '>= 4.3', '< 5.0'
+  spec.add_dependency 'http', '>= 4.3'
   spec.add_dependency 'memoizable', '~> 0.4.0'
   spec.add_dependency 'model_attribute', '~> 3.2'
   spec.add_development_dependency "bundler", ">= 1.7", "< 3.0"
-  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "rake", "~> 13.0"
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = 'https://github.com/taxjar/taxjar-ruby/blob/master/CHANGELOG.md'


### PR DESCRIPTION
Relaxes the requirements around `http`, and bumps `rake` to allow `http` v5 to be installed.

[http changelog](https://github.com/httprb/http/blob/main/CHANGES.md)
[rake changelog](https://github.com/ruby/rake/blob/v13.0.6/History.rdoc)