### PR TITLE
Encodes client user agent using ISO-8859-1 character set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Relaxes `http` version to allow >= 5
+- Encodes client user agent using ISO-8859-1 character set
 
 ## [3.0.3] - 2022-02-07
 - Throw a `Taxjar::Error::GatewayTimeout` exception when receiving a 504 HTTP status code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.0.4] - 2022-08-22
 - Relaxes `http` version to allow >= 5
 - Encodes client user agent using ISO-8859-1 character set
 

--- a/lib/taxjar/client.rb
+++ b/lib/taxjar/client.rb
@@ -45,7 +45,7 @@ module Taxjar
       end
       ruby_version = "ruby #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
       openSSL_version = OpenSSL::OPENSSL_LIBRARY_VERSION
-      "TaxJar/Ruby (#{platform}; #{ruby_version}; #{openSSL_version}) taxjar-ruby/#{Taxjar::Version}"
+      "TaxJar/Ruby (#{platform}; #{ruby_version}; #{openSSL_version}) taxjar-ruby/#{Taxjar::Version}".encode("ISO-8859-1", invalid: :replace, undef: :replace)
     end
   end
 end

--- a/lib/taxjar/version.rb
+++ b/lib/taxjar/version.rb
@@ -1,6 +1,7 @@
 module Taxjar
   module Version
-  module_function
+    module_function
+
     def major
       3
     end
@@ -10,7 +11,7 @@ module Taxjar
     end
 
     def patch
-      3
+      4
     end
 
     def pre
@@ -22,7 +23,7 @@ module Taxjar
         major: major,
         minor: minor,
         patch: patch,
-        pre: pre,
+        pre: pre
       }
     end
 

--- a/spec/taxjar/client_spec.rb
+++ b/spec/taxjar/client_spec.rb
@@ -46,5 +46,11 @@ describe Taxjar::Client do
       client = Taxjar::Client.new(api_key: 'AK')
       expect(client.user_agent).to match(/^TaxJar\/Ruby \(.+\) taxjar-ruby\/\d+\.\d+\.\d+$/)
     end
+
+    it 'encodes using the ISO-8859-1 character set' do
+      client = Taxjar::Client.new(api_key: 'AK')
+      allow(client).to receive(:platform).and_return("Curly’s MacBook Pro")
+      expect(client.user_agent).to match(/Curly\?s MacBook Pro/)
+    end
   end
 end


### PR DESCRIPTION
The default User-Agent set by this library can sometimes include characters that are not valid characters for an HTTP header. When it does this, any requests made by the client result in a 500 response.

https://github.com/taxjar/taxjar-ruby/issues/72

https://ruby-doc.org/core-2.3.0/String.html#method-i-encode