### PR TITLE
Reflect a proper error by response code

### DIFF
--- a/lib/taxjar/error.rb
+++ b/lib/taxjar/error.rb
@@ -67,7 +67,13 @@ module Taxjar
 
       def from_response_code(code)
         message = HTTP::Response::Status::REASONS[code] || "Unknown Error"
-        new(message, code)
+        klass = case code  
+        when 400...500 then ClientError
+        when 500...600 then ServerError
+        else  
+          self
+        end
+        klass.new(message, code)
       end
 
       def for_json_parse_error(code)


### PR DESCRIPTION
In case of 502 response code TaxJar raises base TaxJar::Error rather than  TaxJar::Error::ServerError which is more accurate and allows to handle only server side errors